### PR TITLE
Add mobile and tablet responsive breakpoints (issue #3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+*.tsbuildinfo
 
 # Editor directories and files
 .vscode/*

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,9 +25,16 @@ export default defineConfig({
       },
     },
     {
+      name: 'tablet',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 768, height: 1024 },
+      },
+    },
+    {
       name: 'mobile',
       use: {
-        ...devices['Pixel 5'],
+        ...devices['iPhone SE'],
       },
     },
   ],

--- a/src/components/About/About.module.scss
+++ b/src/components/About/About.module.scss
@@ -6,11 +6,11 @@
   border-top: 1px solid var(--rule);
 
   @media (max-width: #{$bp-md}) {
-    padding: 80px 24px;
+    padding: $spacing-section-y-md $spacing-section-x-md;
   }
 
   @media (max-width: #{$bp-sm}) {
-    padding: 60px 16px;
+    padding: $spacing-section-y-sm $spacing-section-x-sm;
   }
 }
 

--- a/src/components/About/About.module.scss
+++ b/src/components/About/About.module.scss
@@ -4,6 +4,14 @@
   padding: $spacing-section-y $spacing-section-x;
   background: var(--paper);
   border-top: 1px solid var(--rule);
+
+  @media (max-width: #{$bp-md}) {
+    padding: 80px 24px;
+  }
+
+  @media (max-width: #{$bp-sm}) {
+    padding: 60px 16px;
+  }
 }
 
 .about__inner {
@@ -11,6 +19,11 @@
   grid-template-columns: 1fr 2fr;
   gap: 80px;
   max-width: $max-width-inner;
+
+  @media (max-width: #{$bp-md}) {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
 }
 
 .about__label {
@@ -33,6 +46,10 @@
   line-height: 1.3;
   margin: 0;
   font-weight: 400;
+
+  @media (max-width: #{$bp-sm}) {
+    font-size: 28px;
+  }
 }
 
 .about__text {

--- a/src/components/Contact/Contact.module.scss
+++ b/src/components/Contact/Contact.module.scss
@@ -6,11 +6,11 @@
   border-top: 1px solid var(--rule);
 
   @media (max-width: #{$bp-md}) {
-    padding: 80px 24px 48px;
+    padding: $spacing-section-y-md $spacing-section-x-md 48px;
   }
 
   @media (max-width: #{$bp-sm}) {
-    padding: 60px 16px 40px;
+    padding: $spacing-section-y-sm $spacing-section-x-sm 40px;
   }
 }
 

--- a/src/components/Contact/Contact.module.scss
+++ b/src/components/Contact/Contact.module.scss
@@ -4,6 +4,14 @@
   padding: $spacing-section-y $spacing-section-x 60px;
   background: var(--paper-2);
   border-top: 1px solid var(--rule);
+
+  @media (max-width: #{$bp-md}) {
+    padding: 80px 24px 48px;
+  }
+
+  @media (max-width: #{$bp-sm}) {
+    padding: 60px 16px 40px;
+  }
 }
 
 .contact__inner {
@@ -28,6 +36,10 @@
     font-style: italic;
     color: var(--teal-deep);
   }
+
+  @media (max-width: #{$bp-md}) {
+    margin-bottom: 36px;
+  }
 }
 
 .contact__underline {
@@ -39,6 +51,12 @@
   grid-template-columns: repeat(2, 1fr);
   gap: 14px 40px;
   max-width: 640px;
+
+  @media (max-width: #{$bp-card}) {
+    grid-template-columns: 1fr;
+    gap: 0;
+    max-width: 100%;
+  }
 }
 
 .contact__link {
@@ -81,4 +99,10 @@
   color: var(--ink-3);
   display: flex;
   justify-content: space-between;
+
+  @media (max-width: #{$bp-sm}) {
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 48px;
+  }
 }

--- a/src/components/Hero/Hero.module.scss
+++ b/src/components/Hero/Hero.module.scss
@@ -20,12 +20,12 @@
 
   @media (max-width: #{$bp-md}) {
     grid-template-columns: 1fr;
-    padding: 60px 24px 80px;
+    padding: $spacing-section-y-sm $spacing-section-x-md $spacing-section-y-md;
     gap: 40px;
   }
 
   @media (max-width: #{$bp-sm}) {
-    padding: 48px 16px 60px;
+    padding: 48px $spacing-section-x-sm $spacing-section-y-sm;
     gap: 32px;
   }
 }

--- a/src/components/Hero/Hero.module.scss
+++ b/src/components/Hero/Hero.module.scss
@@ -17,6 +17,17 @@
   grid-template-columns: 1fr 320px;
   gap: 48px;
   align-items: center;
+
+  @media (max-width: #{$bp-md}) {
+    grid-template-columns: 1fr;
+    padding: 60px 24px 80px;
+    gap: 40px;
+  }
+
+  @media (max-width: #{$bp-sm}) {
+    padding: 48px 16px 60px;
+    gap: 32px;
+  }
 }
 
 .hero__left {
@@ -75,6 +86,14 @@
 .hero__portrait-wrap {
   justify-self: end;
   position: relative;
+
+  @media (max-width: #{$bp-md}) {
+    justify-self: center;
+  }
+
+  @media (max-width: #{$bp-sm}) {
+    display: none;
+  }
 }
 
 .hero__badge {
@@ -99,10 +118,28 @@
   border-top: 1px solid var(--rule);
   background: var(--stats-wash);
   backdrop-filter: blur(6px);
+
+  @media (max-width: #{$bp-md}) {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 .hero__stat {
   padding: 22px 28px;
+
+  @media (max-width: #{$bp-md}) {
+    &:nth-child(odd) {
+      border-right: 1px solid var(--rule);
+    }
+
+    &:nth-child(-n + 2) {
+      border-bottom: 1px solid var(--rule);
+    }
+  }
+
+  @media (max-width: #{$bp-sm}) {
+    padding: 16px 20px;
+  }
 }
 
 .hero__stat-key {
@@ -116,4 +153,8 @@
 .hero__stat-val {
   font-size: $text-stat;
   font-weight: 500;
+
+  @media (max-width: #{$bp-sm}) {
+    font-size: 28px;
+  }
 }

--- a/src/components/Nav/Nav.module.scss
+++ b/src/components/Nav/Nav.module.scss
@@ -9,11 +9,11 @@
   font-size: $text-label;
 
   @media (max-width: #{$bp-md}) {
-    padding: 20px 24px;
+    padding: 20px $spacing-section-x-md;
   }
 
   @media (max-width: #{$bp-sm}) {
-    padding: 16px;
+    padding: $spacing-section-x-sm;
   }
 }
 
@@ -44,7 +44,7 @@
     display: none;
     position: absolute;
     top: calc(100% - 4px);
-    right: 24px;
+    right: $spacing-section-x-md;
     background: var(--paper);
     border: 1px solid var(--rule);
     border-radius: 12px;
@@ -66,7 +66,7 @@
   }
 
   @media (max-width: #{$bp-sm}) {
-    right: 16px;
+    right: $spacing-section-x-sm;
   }
 
   &--open {

--- a/src/components/Nav/Nav.module.scss
+++ b/src/components/Nav/Nav.module.scss
@@ -7,6 +7,14 @@
   align-items: center;
   padding: 28px $spacing-section-x;
   font-size: $text-label;
+
+  @media (max-width: #{$bp-md}) {
+    padding: 20px 24px;
+  }
+
+  @media (max-width: #{$bp-sm}) {
+    padding: 16px;
+  }
 }
 
 .nav__brand {
@@ -21,12 +29,51 @@
 
 .nav__role {
   color: var(--ink-3);
+
+  @media (max-width: #{$bp-sm}) {
+    display: none;
+  }
 }
 
 .nav__links {
   display: flex;
   gap: 24px;
   opacity: 0.7;
+
+  @media (max-width: #{$bp-md}) {
+    display: none;
+    position: absolute;
+    top: calc(100% - 4px);
+    right: 24px;
+    background: var(--paper);
+    border: 1px solid var(--rule);
+    border-radius: 12px;
+    padding: 4px 20px;
+    flex-direction: column;
+    gap: 0;
+    opacity: 1;
+    z-index: 100;
+    box-shadow: 0 8px 24px -8px oklch(0.24 0.04 220 / 0.12);
+
+    a {
+      padding: 12px 0;
+      border-bottom: 1px solid var(--rule);
+
+      &:last-child {
+        border-bottom: none;
+      }
+    }
+  }
+
+  @media (max-width: #{$bp-sm}) {
+    right: 16px;
+  }
+
+  &--open {
+    @media (max-width: #{$bp-md}) {
+      display: flex;
+    }
+  }
 
   a {
     text-decoration: none;
@@ -47,4 +94,34 @@
 
 .nav__meta {
   color: var(--ink-2);
+
+  @media (max-width: #{$bp-md}) {
+    display: none;
+  }
+}
+
+.nav__hamburger {
+  display: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  font-size: 18px;
+  line-height: 1;
+  padding: 4px 8px;
+  border-radius: 6px;
+  transition: background-color 0.15s;
+
+  &:hover {
+    background: var(--paper-2);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--teal);
+    outline-offset: 2px;
+  }
+
+  @media (max-width: #{$bp-md}) {
+    display: block;
+  }
 }

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -1,7 +1,10 @@
+import { useState } from 'react';
 import { BIO } from '../../data/content';
 import styles from './Nav.module.scss';
 
 export function Nav() {
+  const [menuOpen, setMenuOpen] = useState(false);
+
   return (
     <nav className={`${styles['nav']} mono`}>
       <div className={styles['nav__brand']}>
@@ -17,14 +20,23 @@ export function Nav() {
         <span className={styles['nav__role']}>/ {BIO.role.toLowerCase()}</span>
       </div>
 
-      <div className={styles['nav__links']}>
-        <a href="#work">work</a>
-        <a href="#about">about</a>
-        <a href="#principles">principles</a>
-        <a href="#contact">contact</a>
+      <div className={`${styles['nav__links']} ${menuOpen ? styles['nav__links--open'] : ''}`}>
+        <a href="#work" onClick={() => setMenuOpen(false)}>work</a>
+        <a href="#about" onClick={() => setMenuOpen(false)}>about</a>
+        <a href="#principles" onClick={() => setMenuOpen(false)}>principles</a>
+        <a href="#contact" onClick={() => setMenuOpen(false)}>contact</a>
       </div>
 
       <div className={styles['nav__meta']}>open to advise · {BIO.location}</div>
+
+      <button
+        className={styles['nav__hamburger']}
+        onClick={() => setMenuOpen(!menuOpen)}
+        aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+        aria-expanded={menuOpen}
+      >
+        {menuOpen ? '✕' : '☰'}
+      </button>
     </nav>
   );
 }

--- a/src/components/Principles/Principles.module.scss
+++ b/src/components/Principles/Principles.module.scss
@@ -6,11 +6,11 @@
   color: var(--paper);
 
   @media (max-width: #{$bp-md}) {
-    padding: 80px 24px;
+    padding: $spacing-section-y-md $spacing-section-x-md;
   }
 
   @media (max-width: #{$bp-sm}) {
-    padding: 60px 16px;
+    padding: $spacing-section-y-sm $spacing-section-x-sm;
   }
 }
 
@@ -38,13 +38,13 @@
   }
 
   @media (max-width: #{$bp-md}) {
-    font-size: 40px;
-    margin-bottom: 40px;
+    font-size: $text-heading-lg-md;
+    margin-bottom: $text-heading-lg-md;
   }
 
   @media (max-width: #{$bp-sm}) {
-    font-size: 32px;
-    margin-bottom: 32px;
+    font-size: $text-heading-lg-sm;
+    margin-bottom: $text-heading-lg-sm;
   }
 }
 

--- a/src/components/Principles/Principles.module.scss
+++ b/src/components/Principles/Principles.module.scss
@@ -4,6 +4,14 @@
   padding: $spacing-section-y $spacing-section-x;
   background: var(--ink);
   color: var(--paper);
+
+  @media (max-width: #{$bp-md}) {
+    padding: 80px 24px;
+  }
+
+  @media (max-width: #{$bp-sm}) {
+    padding: 60px 16px;
+  }
 }
 
 .principles__inner {
@@ -28,12 +36,27 @@
     font-style: italic;
     color: var(--moss-light);
   }
+
+  @media (max-width: #{$bp-md}) {
+    font-size: 40px;
+    margin-bottom: 40px;
+  }
+
+  @media (max-width: #{$bp-sm}) {
+    font-size: 32px;
+    margin-bottom: 32px;
+  }
 }
 
 .principles__grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 48px 64px;
+
+  @media (max-width: #{$bp-md}) {
+    grid-template-columns: 1fr;
+    gap: 40px;
+  }
 }
 
 .principles__item {

--- a/src/components/Projects/Projects.module.scss
+++ b/src/components/Projects/Projects.module.scss
@@ -5,11 +5,11 @@
   background: var(--paper);
 
   @media (max-width: #{$bp-md}) {
-    padding: 80px 24px;
+    padding: $spacing-section-y-md $spacing-section-x-md;
   }
 
   @media (max-width: #{$bp-sm}) {
-    padding: 60px 16px;
+    padding: $spacing-section-y-sm $spacing-section-x-sm;
   }
 }
 
@@ -40,13 +40,13 @@
   }
 
   @media (max-width: #{$bp-md}) {
-    font-size: 40px;
-    margin-bottom: 40px;
+    font-size: $text-heading-lg-md;
+    margin-bottom: $text-heading-lg-md;
   }
 
   @media (max-width: #{$bp-sm}) {
-    font-size: 32px;
-    margin-bottom: 32px;
+    font-size: $text-heading-lg-sm;
+    margin-bottom: $text-heading-lg-sm;
   }
 }
 

--- a/src/components/Projects/Projects.module.scss
+++ b/src/components/Projects/Projects.module.scss
@@ -3,6 +3,14 @@
 .projects {
   padding: $spacing-section-y $spacing-section-x;
   background: var(--paper);
+
+  @media (max-width: #{$bp-md}) {
+    padding: 80px 24px;
+  }
+
+  @media (max-width: #{$bp-sm}) {
+    padding: 60px 16px;
+  }
 }
 
 .projects__inner {
@@ -30,12 +38,26 @@
     font-style: italic;
     color: var(--teal-deep);
   }
+
+  @media (max-width: #{$bp-md}) {
+    font-size: 40px;
+    margin-bottom: 40px;
+  }
+
+  @media (max-width: #{$bp-sm}) {
+    font-size: 32px;
+    margin-bottom: 32px;
+  }
 }
 
 .projects__grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 24px;
+
+  @media (max-width: #{$bp-card}) {
+    grid-template-columns: 1fr;
+  }
 }
 
 .projects__card {

--- a/src/components/Stack/Stack.module.scss
+++ b/src/components/Stack/Stack.module.scss
@@ -5,11 +5,11 @@
   background: var(--paper);
 
   @media (max-width: #{$bp-md}) {
-    padding: 80px 24px;
+    padding: $spacing-section-y-md $spacing-section-x-md;
   }
 
   @media (max-width: #{$bp-sm}) {
-    padding: 60px 16px;
+    padding: $spacing-section-y-sm $spacing-section-x-sm;
   }
 }
 

--- a/src/components/Stack/Stack.module.scss
+++ b/src/components/Stack/Stack.module.scss
@@ -3,6 +3,14 @@
 .stack {
   padding: $spacing-section-y $spacing-section-x;
   background: var(--paper);
+
+  @media (max-width: #{$bp-md}) {
+    padding: 80px 24px;
+  }
+
+  @media (max-width: #{$bp-sm}) {
+    padding: 60px 16px;
+  }
 }
 
 .stack__inner {
@@ -24,6 +32,16 @@
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 32px;
+
+  @media (max-width: #{$bp-md}) {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 24px;
+  }
+
+  @media (max-width: #{$bp-sm}) {
+    grid-template-columns: 1fr;
+    gap: 20px;
+  }
 }
 
 .stack__group-name {

--- a/src/components/Timeline/Timeline.module.scss
+++ b/src/components/Timeline/Timeline.module.scss
@@ -5,11 +5,11 @@
   background: var(--paper-2);
 
   @media (max-width: #{$bp-md}) {
-    padding: 80px 24px;
+    padding: $spacing-section-y-md $spacing-section-x-md;
   }
 
   @media (max-width: #{$bp-sm}) {
-    padding: 60px 16px;
+    padding: $spacing-section-y-sm $spacing-section-x-sm;
   }
 }
 

--- a/src/components/Timeline/Timeline.module.scss
+++ b/src/components/Timeline/Timeline.module.scss
@@ -3,6 +3,14 @@
 .timeline {
   padding: $spacing-section-y $spacing-section-x;
   background: var(--paper-2);
+
+  @media (max-width: #{$bp-md}) {
+    padding: 80px 24px;
+  }
+
+  @media (max-width: #{$bp-sm}) {
+    padding: 60px 16px;
+  }
 }
 
 .timeline__inner {
@@ -37,6 +45,17 @@
   padding: 28px 0;
   border-top: 1px solid var(--rule);
   align-items: baseline;
+
+  @media (max-width: #{$bp-md}) {
+    grid-template-columns: 80px 1fr;
+    gap: 20px;
+  }
+
+  @media (max-width: #{$bp-sm}) {
+    grid-template-columns: 1fr;
+    gap: 6px;
+    padding: 20px 0;
+  }
 }
 
 .timeline__year {
@@ -48,6 +67,10 @@
   font-size: $text-heading-sm;
   font-weight: 500;
   line-height: 1.1;
+
+  @media (max-width: #{$bp-sm}) {
+    font-size: 22px;
+  }
 }
 
 .timeline__note {
@@ -60,4 +83,14 @@
   text-align: right;
   font-size: $text-label;
   color: var(--ink-2);
+
+  @media (max-width: #{$bp-md}) {
+    grid-column: 2;
+    text-align: left;
+  }
+
+  @media (max-width: #{$bp-sm}) {
+    grid-column: auto;
+    text-align: left;
+  }
 }

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -38,3 +38,9 @@ $max-width-inner:   1100px; // section content max-width
 $radius-pill:       999px;  // pill / dot border-radius
 $radius-card:       22px;   // project card border-radius
 $underline-width:   4px;    // decorative heading underline stroke
+
+// Responsive breakpoints
+$bp-sm:   480px;   // small mobile — portrait hidden, stack 1-col
+$bp-card: 600px;   // card grids collapse to single column
+$bp-md:   768px;   // tablet portrait — nav hamburger, major reflows
+$bp-lg:   1100px;  // matches $max-width-inner

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -44,3 +44,13 @@ $bp-sm:   480px;   // small mobile — portrait hidden, stack 1-col
 $bp-card: 600px;   // card grids collapse to single column
 $bp-md:   768px;   // tablet portrait — nav hamburger, major reflows
 $bp-lg:   1100px;  // matches $max-width-inner
+
+// Responsive spacing — section padding at each breakpoint
+$spacing-section-x-md: 24px;  // tablet horizontal padding
+$spacing-section-x-sm: 16px;  // mobile horizontal padding
+$spacing-section-y-md: 80px;  // tablet vertical padding
+$spacing-section-y-sm: 60px;  // mobile vertical padding
+
+// Responsive type — large section heading scaled for smaller viewports
+$text-heading-lg-md: 40px;
+$text-heading-lg-sm: 32px;


### PR DESCRIPTION
- Add $bp-sm (480px), $bp-card (600px), $bp-md (768px), $bp-lg (1100px) to variables.scss
- Nav: hamburger dropdown menu at ≤768px, hides meta and role text on small screens
- Hero: single-column layout at ≤768px, portrait hidden at ≤480px, stats strip 2×2 at ≤768px
- Projects: 1-column grid at ≤600px, scaled heading sizes on mobile
- About: 1-column layout at ≤768px
- Principles: 1-column grid at ≤768px, scaled heading sizes on mobile
- Stack: 4→2 columns at ≤768px, 2→1 at ≤480px
- Timeline: 3-col→2-col at ≤768px (org wraps under role), 1-col stack at ≤480px
- Contact: 1-column links at ≤600px, footer stacks vertically at ≤480px
- All sections: reduced horizontal padding (24px tablet, 16px mobile)

https://claude.ai/code/session_01UP1aqwPvKLk8GJAeHWTdoc