### PR TITLE
Set Chromium as browser for mobile test configuration

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -35,6 +35,7 @@ export default defineConfig({
       name: 'mobile',
       use: {
         ...devices['iPhone SE'],
+        browserName: 'chromium',
       },
     },
   ],


### PR DESCRIPTION
## Summary
Updated the mobile test configuration in Playwright to explicitly specify Chromium as the browser engine, overriding the default browser that would be used with the iPhone SE device preset.

## Changes
- Added `browserName: 'chromium'` to the mobile device configuration in `playwright.config.ts`

## Details
The mobile test profile now explicitly uses Chromium as the browser engine while maintaining all other iPhone SE device settings (viewport, user agent, etc.). This ensures consistent browser behavior across mobile test runs and prevents any ambiguity about which browser engine is being used for mobile testing.

https://claude.ai/code/session_013sCzhC8xqCBTag5tQBxKXT